### PR TITLE
Add enums

### DIFF
--- a/packages/python/src/components/Enum.tsx
+++ b/packages/python/src/components/Enum.tsx
@@ -1,0 +1,98 @@
+import { Children, For, Refkey } from "@alloy-js/core";
+import { usePythonNamePolicy } from "../name-policy.js";
+import { createPythonSymbol } from "../symbols/index.js";
+import { Class } from "./Class.js";
+import { DeclarationProps } from "./Declaration.js";
+import { EnumMember } from "./EnumMember.js";
+import { useSourceFileContext } from "./SourceFile.js";
+
+export interface EnumProps extends DeclarationProps {
+  /**
+   * The base type of the enum. One of: 'Enum', 'IntEnum', 'StrEnum', 'Flag', 'IntFlag'.
+   * Defaults to 'Enum'.
+   */
+  baseType?: "Enum" | "IntEnum" | "StrEnum" | "Flag" | "IntFlag";
+  /**
+   * Members of the enum as an array of objects.
+   */
+  members?: Array<{ name: string; value?: string | number }>;
+  /**
+   * The enum style: 'classic' (default), 'auto', or 'functional'.
+   */
+  style?: "classic" | "auto" | "functional";
+  /**
+   * Optional docstring for the enum.
+   */
+  doc?: Children;
+  /**
+   * Children can be additional Enum components.
+   */
+  children?: Children;
+  /**
+   * Optional refkey for symbol referencing.
+   */
+  refkey?: Refkey;
+}
+
+/**
+ * A Python enum declaration, following https://docs.python.org/3.11/library/enum.html
+ */
+export function Enum(props: EnumProps) {
+  const baseType = props.baseType || "Enum";
+  const sfContext = useSourceFileContext();
+  sfContext.addImport(
+    createPythonSymbol({
+      name: baseType,
+      module: "enum",
+    }),
+  );
+
+  // Handle enum styles
+  if (props.style === "functional") {
+    const name = usePythonNamePolicy().getName(props.name, "enum");
+    const members = props.members ?? [];
+    let opener, ender;
+    if (members.length && members.every((m) => m.value === undefined)) {
+      // List of names: Enum('Direction', ['NORTH', ...])
+      opener = "[";
+      ender = "]";
+    } else {
+      // List of name-value pairs: Enum('Direction', {'NORTH': 1, ...})
+      opener = "{";
+      ender = "}";
+    }
+    const memberExpr = (
+      <>
+        {opener}
+        <For each={members} joiner=", ">
+          {(m) => (
+            <EnumMember name={m.name} value={m.value} functional={true} />
+          )}
+        </For>
+        {ender}
+      </>
+    );
+    return (
+      <>
+        {name} = {baseType}('{name}', {memberExpr})
+      </>
+    );
+  }
+
+  let memberList: Array<{ name: string; value?: string | number }> =
+    props.members ?? [];
+  if (props.style === "auto") {
+    sfContext.addImport(createPythonSymbol({ name: "auto", module: "enum" }));
+    memberList = memberList.map((m) =>
+      m.value === undefined ? { name: m.name, value: "auto()" } : m,
+    );
+  }
+  return (
+    <Class name={props.name} bases={[baseType]}>
+      <For each={memberList} hardline>
+        {(member) => <EnumMember name={member.name} value={member.value} />}
+      </For>
+      {props.children}
+    </Class>
+  );
+}

--- a/packages/python/src/components/EnumMember.tsx
+++ b/packages/python/src/components/EnumMember.tsx
@@ -1,0 +1,39 @@
+import { Children, Show } from "@alloy-js/core";
+import { usePythonNamePolicy } from "../name-policy.js";
+
+export interface EnumMemberProps {
+  /**
+   * The name of the enum member.
+   */
+  name: string;
+
+  /**
+   * The value of the enum member.
+   */
+  value?: Children;
+
+  /**
+   * Functional mappings/list
+   */
+  functional?: boolean;
+}
+
+/**
+ * A Python enum member.
+ */
+export function EnumMember(props: EnumMemberProps) {
+  const name = usePythonNamePolicy().getName(props.name, "class");
+  if (props.functional) {
+    return (
+      <>
+        '{name}'<Show when={props.value !== undefined}> : {props.value}</Show>
+      </>
+    );
+  }
+  return (
+    <>
+      {props.name}
+      <Show when={props.value !== undefined}> = {props.value}</Show>
+    </>
+  );
+}

--- a/packages/python/src/components/SourceFile.tsx
+++ b/packages/python/src/components/SourceFile.tsx
@@ -6,6 +6,7 @@ import {
   OutputSymbol,
   reactive,
   Scope,
+  useContext,
 } from "@alloy-js/core";
 import { Children } from "@alloy-js/core/jsx-runtime";
 import { usePythonNamePolicy } from "../name-policy.js";
@@ -21,6 +22,11 @@ export interface SourceFileContext extends CoreSourceFileContext {
 
 export const SourceFileContext: ComponentContext<SourceFileContext> =
   createContext();
+
+// Context accessor
+export function useSourceFileContext(): SourceFileContext {
+  return useContext(SourceFileContext)!;
+}
 
 export interface SourceFileProps {
   path: string;

--- a/packages/python/src/components/index.ts
+++ b/packages/python/src/components/index.ts
@@ -1,5 +1,7 @@
 export * from "./Class.js";
 export * from "./Declaration.js";
+export * from "./Enum.js";
+export * from "./EnumMember.js";
 export * from "./ImportStatement.js";
 export * from "./Method.js";
 export * from "./Parameters.js";

--- a/packages/python/test/enums.test.tsx
+++ b/packages/python/test/enums.test.tsx
@@ -1,0 +1,138 @@
+import { Output, render } from "@alloy-js/core";
+import { describe, it } from "vitest";
+import * as py from "../src/components/index.js";
+import { assertFileContents } from "./utils.jsx";
+
+describe("Python Enum", () => {
+  it("classic enum with explicit values", () => {
+    const result = render(
+      <Output>
+        <py.SourceFile path="test.py">
+          <py.Enum
+            name="Color"
+            baseType="IntEnum"
+            members={[
+              { name: "RED", value: 1 },
+              { name: "GREEN", value: 2 },
+              { name: "BLUE", value: 3 },
+            ]}
+          />
+        </py.SourceFile>
+      </Output>,
+    );
+    const expected = [
+      "from enum import IntEnum",
+      "class Color(IntEnum):",
+      "  RED = 1",
+      "  GREEN = 2",
+      "  BLUE = 3",
+      "",
+      "",
+    ].join("\n");
+    assertFileContents(result, { "test.py": expected });
+  });
+
+  it("enum with auto() values", () => {
+    const result = render(
+      <Output>
+        <py.SourceFile path="test.py">
+          <py.Enum
+            name="Animal"
+            style="auto"
+            members={[{ name: "DOG" }, { name: "CAT" }, { name: "RABBIT" }]}
+          />
+        </py.SourceFile>
+      </Output>,
+    );
+    const expected = [
+      "from enum import Enum",
+      "from enum import auto",
+      "class Animal(Enum):",
+      "  DOG = auto()",
+      "  CAT = auto()",
+      "  RABBIT = auto()",
+      "",
+      "",
+    ].join("\n");
+    assertFileContents(result, { "test.py": expected });
+  });
+
+  it("enum with mixed manual and auto() values", () => {
+    const result = render(
+      <Output>
+        <py.SourceFile path="test.py">
+          <py.Enum
+            name="Permission"
+            baseType="Flag"
+            style="auto"
+            members={[
+              { name: "READ", value: 1 },
+              { name: "WRITE" },
+              { name: "EXECUTE" },
+            ]}
+          />
+        </py.SourceFile>
+      </Output>,
+    );
+    const expected = [
+      "from enum import Flag",
+      "from enum import auto",
+      "class Permission(Flag):",
+      "  READ = 1",
+      "  WRITE = auto()",
+      "  EXECUTE = auto()",
+      "",
+      "",
+    ].join("\n");
+    assertFileContents(result, { "test.py": expected });
+  });
+
+  it("functional enum with list", () => {
+    const result = render(
+      <Output>
+        <py.SourceFile path="test.py">
+          <py.Enum
+            name="Direction"
+            style="functional"
+            members={[
+              { name: "NORTH" },
+              { name: "SOUTH" },
+              { name: "EAST" },
+              { name: "WEST" },
+            ]}
+          />
+        </py.SourceFile>
+      </Output>,
+    );
+    const expected = [
+      "from enum import Enum",
+      "Direction = Enum('Direction', ['NORTH', 'SOUTH', 'EAST', 'WEST'])",
+      "",
+    ].join("\n");
+    assertFileContents(result, { "test.py": expected });
+  });
+
+  it("functional enum with mapping", () => {
+    const result = render(
+      <Output>
+        <py.SourceFile path="test.py">
+          <py.Enum
+            name="Priority"
+            style="functional"
+            members={[
+              { name: "HIGH", value: 1 },
+              { name: "MEDIUM", value: 2 },
+              { name: "LOW", value: 3 },
+            ]}
+          />
+        </py.SourceFile>
+      </Output>,
+    );
+    const expected = [
+      "from enum import Enum",
+      "Priority = Enum('Priority', {'HIGH' : 1, 'MEDIUM' : 2, 'LOW' : 3})",
+      "",
+    ].join("\n");
+    assertFileContents(result, { "test.py": expected });
+  });
+});


### PR DESCRIPTION
Add enum support. The following python enums are supported:

Functional API:
```
from enum import Enum

Direction = Enum('Direction', ['NORTH', 'SOUTH', 'EAST', 'WEST'])
```

Regular enums:
```
from enum import Enum

class Color(Enum):
    RED = 1
    GREEN = 2
    BLUE = 3
```

IntEnum and StrEnum:

```
from enum import IntEnum

class Status(IntEnum):
    OK = 200
    NOT_FOUND = 404
    ERROR = 500
```

```
from enum import StrEnum

class Weekday(StrEnum):  # StrEnum in Python 3.11+
    MONDAY = "Monday"
    TUESDAY = "Tuesday"
```

Auto and Flag:
```
from enum import Flag, auto

class Permission(Flag):
    READ = auto()
    WRITE = auto()
    EXECUTE = auto()
```

Haven't implemented Doc yet, something to do for all components where it makes sense.