### PR TITLE
Remove <Block> from the class and method renders

### DIFF
--- a/packages/python/src/components/Class.tsx
+++ b/packages/python/src/components/Class.tsx
@@ -1,4 +1,4 @@
-import { Block, Children, List, Scope, Show } from "@alloy-js/core";
+import { Children, Indent, List, Scope, Show } from "@alloy-js/core";
 import { usePythonNamePolicy } from "../name-policy.js";
 import { Declaration, DeclarationProps } from "./Declaration.js";
 
@@ -20,10 +20,9 @@ export function Class(props: ClassProps) {
         <Show when={props.bases !== undefined && props.bases.length > 0}>
           (<List children={props.bases} comma space />)
         </Show>
+        :
         <Scope name={name} kind="class">
-          <Block opener=":" closer="">
-            {hasChildren ? props.children : "pass"}
-          </Block>
+          <Indent>{hasChildren ? props.children : "pass"}</Indent>
         </Scope>
       </group>
     </Declaration>

--- a/packages/python/src/components/Method.tsx
+++ b/packages/python/src/components/Method.tsx
@@ -1,4 +1,4 @@
-import { Block, Children, Scope } from "@alloy-js/core";
+import { Children, Indent, Scope } from "@alloy-js/core";
 import { usePythonNamePolicy } from "../name-policy.js";
 import { Declaration } from "./Declaration.jsx";
 import { Parameters, ParametersProps } from "./Parameters.jsx";
@@ -34,11 +34,9 @@ export function Method(props: MethodProps) {
   return (
     <Declaration {...props} name={name}>
       <group>
-        def {name}({params})
+        def {name}({params}):
         <Scope name={name} kind="method">
-          <Block opener=":" closer="">
-            {props.children ?? "pass"}
-          </Block>
+          <Indent>{props.children ?? "pass"}</Indent>
         </Scope>
       </group>
     </Declaration>

--- a/packages/python/test/classes.test.tsx
+++ b/packages/python/test/classes.test.tsx
@@ -1,4 +1,5 @@
 import { List, Output, refkey, render } from "@alloy-js/core";
+import { d } from "@alloy-js/core/testing";
 import { describe, expect, it } from "vitest";
 import * as py from "../src/components/index.js";
 import { assertFileContents, toSourceText } from "./utils.jsx";
@@ -12,7 +13,10 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`class Foo:\n  pass\n\n`);
+    expect(result).toRenderTo(d`
+      class Foo:
+        pass
+    `);
   });
 
   it("renders a class with a body", () => {
@@ -23,7 +27,10 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`class Bar:\n  print('hi')\n\n`);
+    expect(result).toRenderTo(d`
+      class Bar:
+        print('hi')
+    `);
   });
 
   it("renders a class with base classes", () => {
@@ -32,22 +39,22 @@ describe("Python Class", () => {
         <py.SourceFile path="test.py">
           {[
             <py.Class name="Base1" />,
+            <br />,
             <py.Class name="Base2" />,
+            <br />,
             <py.Class name="Baz" bases={[refkey("Base1"), refkey("Base2")]} />,
           ]}
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "class Base1:",
-      "  pass",
-      "class Base2:",
-      "  pass",
-      "class Baz(Base1, Base2):",
-      "  pass",
-      "",
-      "",
-    ].join("\n");
+    const expected = d`
+      class Base1:
+        pass
+      class Base2:
+        pass
+      class Baz(Base1, Base2):
+        pass
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 
@@ -61,7 +68,10 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`class Qux(Base):\n  print('hello')\n\n`);
+    expect(result).toRenderTo(d`
+      class Qux(Base):
+        print('hello')
+    `);
   });
 
   it("renders classes across modules with inheritance", () => {
@@ -75,14 +85,15 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    const mod1Expected = ["class A:", "  pass", "", ""].join("\n");
-    const mod2Expected = [
-      "from mod1 import A",
-      "class B(A):",
-      "  pass",
-      "",
-      "",
-    ].join("\n");
+    const mod1Expected = d`
+      class A:
+        pass
+    `;
+    const mod2Expected = d`
+      from mod1 import A
+      class B(A):
+        pass
+    `;
     assertFileContents(result, { "mod1.py": mod1Expected });
     assertFileContents(result, { "mod2.py": mod2Expected });
   });
@@ -92,6 +103,7 @@ describe("Python Class", () => {
       <Output>
         <py.SourceFile path="test.py">
           <py.Class name="A" />
+          <br />
           <py.Class name="B">
             <List hardline>
               <py.Variable name="bar" type={refkey("A")} omitNone />
@@ -101,15 +113,13 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "class A:",
-      "  pass",
-      "class B:",
-      "  bar: A",
-      "  foo: str",
-      "",
-      "",
-    ].join("\n");
+    const expected = d`
+      class A:
+        pass
+      class B:
+        bar: A
+        foo: str
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 });

--- a/packages/python/test/enums.test.tsx
+++ b/packages/python/test/enums.test.tsx
@@ -2,6 +2,7 @@ import { Output, render } from "@alloy-js/core";
 import { describe, it } from "vitest";
 import * as py from "../src/components/index.js";
 import { assertFileContents } from "./utils.jsx";
+import { d } from "@alloy-js/core/testing";
 
 describe("Python Enum", () => {
   it("classic enum with explicit values", () => {
@@ -20,15 +21,13 @@ describe("Python Enum", () => {
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "from enum import IntEnum",
-      "class Color(IntEnum):",
-      "  RED = 1",
-      "  GREEN = 2",
-      "  BLUE = 3",
-      "",
-      "",
-    ].join("\n");
+    const expected = d`
+      from enum import IntEnum
+      class Color(IntEnum):
+        RED = 1
+        GREEN = 2
+        BLUE = 3
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 
@@ -44,16 +43,14 @@ describe("Python Enum", () => {
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "from enum import Enum",
-      "from enum import auto",
-      "class Animal(Enum):",
-      "  DOG = auto()",
-      "  CAT = auto()",
-      "  RABBIT = auto()",
-      "",
-      "",
-    ].join("\n");
+    const expected = d`
+      from enum import Enum
+      from enum import auto
+      class Animal(Enum):
+        DOG = auto()
+        CAT = auto()
+        RABBIT = auto()
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 
@@ -74,16 +71,14 @@ describe("Python Enum", () => {
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "from enum import Flag",
-      "from enum import auto",
-      "class Permission(Flag):",
-      "  READ = 1",
-      "  WRITE = auto()",
-      "  EXECUTE = auto()",
-      "",
-      "",
-    ].join("\n");
+    const expected = d`
+      from enum import Flag
+      from enum import auto
+      class Permission(Flag):
+        READ = 1
+        WRITE = auto()
+        EXECUTE = auto()
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 
@@ -104,11 +99,10 @@ describe("Python Enum", () => {
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "from enum import Enum",
-      "Direction = Enum('Direction', ['NORTH', 'SOUTH', 'EAST', 'WEST'])",
-      "",
-    ].join("\n");
+    const expected = d`
+      from enum import Enum
+      Direction = Enum('Direction', ['NORTH', 'SOUTH', 'EAST', 'WEST'])
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 
@@ -128,11 +122,10 @@ describe("Python Enum", () => {
         </py.SourceFile>
       </Output>,
     );
-    const expected = [
-      "from enum import Enum",
-      "Priority = Enum('Priority', {'HIGH' : 1, 'MEDIUM' : 2, 'LOW' : 3})",
-      "",
-    ].join("\n");
+    const expected = d`
+      from enum import Enum
+      Priority = Enum('Priority', {'HIGH' : 1, 'MEDIUM' : 2, 'LOW' : 3})
+    `;
     assertFileContents(result, { "test.py": expected });
   });
 });

--- a/packages/python/test/methods.test.tsx
+++ b/packages/python/test/methods.test.tsx
@@ -1,9 +1,10 @@
 import { Output } from "@alloy-js/core";
+import { d } from "@alloy-js/core/testing";
 import { describe, expect, it } from "vitest";
 import * as py from "../src/components/index.js";
 import { toSourceText } from "./utils.jsx";
 
-describe("Python Class", () => {
+describe("Python Method", () => {
   it("renders a method with no body as 'pass'", () => {
     const result = toSourceText(
       <Output>
@@ -12,7 +13,10 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`def foo(self):\n  pass\n\n`);
+    expect(result).toRenderTo(d`
+      def foo(self):
+        pass
+    `);
   });
 
   it("renders an instance method with a body", () => {
@@ -25,7 +29,10 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`def bar(self):\n  print('hi')\n\n`);
+    expect(result).toRenderTo(d`
+      def bar(self):
+        print('hi')
+    `);
   });
 
   it("renders a class method with a body", () => {
@@ -38,7 +45,10 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`def bar(cls):\n  print('hi')\n\n`);
+    expect(result).toRenderTo(d`
+      def bar(cls):
+        print('hi')
+    `);
   });
 
   it("renders a function with parameters", () => {
@@ -60,7 +70,10 @@ describe("Python Class", () => {
       </Output>,
     );
     expect(result).toRenderTo(
-      `def baz(x: int, y = 0, *args, **kwargs):\n  print(x, y)\n\n`,
+      d`
+        def baz(x: int, y = 0, *args, **kwargs):
+          print(x, y)
+      `,
     );
   });
 
@@ -74,6 +87,9 @@ describe("Python Class", () => {
         </py.SourceFile>
       </Output>,
     );
-    expect(result).toRenderTo(`def __init__(self, x, y = 0):\n  pass\n\n`);
+    expect(result).toRenderTo(d`
+      def __init__(self, x, y = 0):
+        pass
+    `);
   });
 });


### PR DESCRIPTION
I don't think we should have random spaces in the codegen for classes or methods. Instead we should create a `StatementList` for creating code for these that an emitter can use. So, removing the `<Block>` jsx from these.