### PR TITLE
Add docstring/comment components

### DIFF
--- a/packages/python/src/components/ClassDeclaration.tsx
+++ b/packages/python/src/components/ClassDeclaration.tsx
@@ -1,9 +1,11 @@
 import {
   Children,
+  Indent,
   List,
   Name,
   OutputSymbolFlags,
   Scope,
+  Show,
   childrenArray,
   takeSymbols,
 } from "@alloy-js/core";
@@ -14,6 +16,7 @@ import {
   DeclarationProps,
 } from "./Declaration.js";
 import { PythonBlock } from "./PythonBlock.jsx";
+import { PyDoc } from "./index.js";
 
 export interface ClassDeclarationProps extends BaseDeclarationProps {
   /**
@@ -88,6 +91,9 @@ export function ClassDeclaration(props: ClassDeclarationProps) {
       <Scope name={updatedProps.name} kind="class">
         {basesPart}
         <PythonBlock opener=":">
+          <Show when={Boolean(props.doc)}>
+            {props.doc}
+          </Show>
           {hasChildren ? props.children : "pass"}
         </PythonBlock>
       </Scope>

--- a/packages/python/src/components/EnumDeclaration.tsx
+++ b/packages/python/src/components/EnumDeclaration.tsx
@@ -5,6 +5,7 @@ import {
   MemberScope,
   OutputSymbolFlags,
   Scope,
+  Show,
   useBinder,
 } from "@alloy-js/core";
 import { enumModule } from "../builtins/python.js";
@@ -13,6 +14,7 @@ import { usePythonScope } from "../symbols/scopes.js";
 import { BaseDeclarationProps } from "./Declaration.js";
 import { EnumMember } from "./EnumMember.js";
 import { PythonBlock } from "./PythonBlock.jsx";
+import { SimpleCommentBlock } from "./index.js";
 
 export interface EnumProps extends BaseDeclarationProps {
   /**
@@ -139,6 +141,7 @@ export function ClassEnumDeclaration(props: EnumProps) {
     value?: Children;
     jsValue?: string | number;
     auto?: boolean;
+    doc?: string;
   }> = (props.members ?? []).map((m) =>
     m.value === undefined ? { ...m, auto: false } : m,
   );
@@ -149,6 +152,10 @@ export function ClassEnumDeclaration(props: EnumProps) {
   }
   return (
     <CoreDeclaration symbol={sym}>
+      <Show when={Boolean(props.doc)}>
+        <SimpleCommentBlock children={props.doc} />
+        <hbr />
+      </Show>
       class {sym.name}({enumModule["."][baseType]})
       <MemberScope owner={sym}>
         <Scope name={sym.name} kind="enum">
@@ -160,6 +167,7 @@ export function ClassEnumDeclaration(props: EnumProps) {
                   value={member.value}
                   jsValue={member.jsValue}
                   auto={member.auto}
+                  doc={member.doc}
                 />
               )}
             </For>

--- a/packages/python/src/components/EnumMember.tsx
+++ b/packages/python/src/components/EnumMember.tsx
@@ -3,6 +3,7 @@ import { enumModule } from "../builtins/python.js";
 import { createPythonSymbol } from "../symbol-creation.js";
 import { PythonOutputSymbol } from "../symbols/index.js";
 import { Value } from "./Value.jsx";
+import { SimpleInlineComment } from "./index.js";
 
 export interface EnumMemberProps {
   /**
@@ -73,6 +74,9 @@ export function EnumMember(props: EnumMemberProps) {
     return (
       <>
         '{sym.name}'<Show when={valueCode !== undefined}> : {valueCode}</Show>
+        <Show when={props.doc !== undefined}>
+          <SimpleInlineComment>{props.doc}</SimpleInlineComment>
+        </Show>
       </>
     );
   }
@@ -80,6 +84,9 @@ export function EnumMember(props: EnumMemberProps) {
     <>
       {sym.name}
       <Show when={valueCode !== undefined}> = {valueCode}</Show>
+      <Show when={props.doc !== undefined}>
+        <SimpleInlineComment>{props.doc}</SimpleInlineComment>
+      </Show>
     </>
   );
 }

--- a/packages/python/src/components/FunctionDeclaration.tsx
+++ b/packages/python/src/components/FunctionDeclaration.tsx
@@ -4,6 +4,7 @@ import {
   OutputScope,
   OutputSymbolFlags,
   Scope,
+  Show,
   useMemberScope,
   useScope,
 } from "@alloy-js/core";
@@ -73,7 +74,12 @@ export function FunctionDeclaration(props: FunctionDeclarationProps) {
             {...callSignatureProps}
             returnType={props.returnType}
           />
-          <PythonBlock opener=":">{props.children ?? "pass"}</PythonBlock>
+          <PythonBlock opener=":">
+            <Show when={Boolean(props.doc)}>
+              {props.doc}
+            </Show>
+            {props.children ?? "pass"}
+          </PythonBlock>
         </Scope>
       </Declaration>
     </>

--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -1,0 +1,305 @@
+import { For, Prose, Show, List, childrenArray, Indent, baseListPropsToMapJoinArgs } from "@alloy-js/core";
+import { Children } from "@alloy-js/core/jsx-runtime";
+import { ParameterDescriptor } from "../parameter-descriptor.js";
+import { Value } from "./index.js";
+
+
+interface GoogleStyleDocParamTypeProps {
+  type?: Children;
+  optional?: boolean;
+}
+
+function GoogleStyleDocParamType(props: GoogleStyleDocParamTypeProps) {
+  return (
+    <>
+      <Show when={Boolean(props.type)}>
+        {" ("}
+        {props.type}
+        <Show when={props.optional}>{", optional"}</Show>
+        {")"}
+      </Show>
+    </>
+  );
+}
+
+interface GoogleStyleDocParamNameProps{
+  name: Children;
+}
+
+function GoogleStyleDocParamName(props: GoogleStyleDocParamNameProps) {
+  return (
+    <>
+      {props.name}
+    </>
+  );
+}
+
+interface GoogleStyleDocParamDescriptionProps {
+  children?: Children;
+  defaultValue?: Children;
+}
+
+function GoogleStyleDocParamDescription(props: GoogleStyleDocParamDescriptionProps) {
+  return (
+    <Show when={Boolean(props.children)}>
+      {": "}
+      <align width={4}>
+        <Prose>{props.children}</Prose>
+        <Show when={Boolean(props.defaultValue)}> Defaults to <Value jsValue={props.defaultValue}></Value>.</Show>
+      </align>
+    </Show>
+  );
+}
+
+export interface GoogleStyleDocParamProps {
+  name: Children;
+  type?: Children;
+  children?: Children;
+  optional?: boolean;
+  defaultValue?: Children;
+}
+
+/**
+ * Create a GoogleStyleDoc parameter.
+ */
+export function GoogleStyleDocParam(props: GoogleStyleDocParamProps) {
+  return (
+    <>
+      <GoogleStyleDocParamName
+        name={props.name}
+      />
+      <GoogleStyleDocParamType type={props.type} optional={props.optional} />
+      <GoogleStyleDocParamDescription children={props.children} defaultValue={props.defaultValue}/>
+    </>
+  );
+}
+
+export interface GoogleStyleDocParamsProps {
+  parameters: ParameterDescriptor[] | string[];
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for parameters.
+ */
+export function GoogleStyleDocParams(props: GoogleStyleDocParamsProps) {
+  const parameters = normalizeParametersForDoc(props.parameters);
+  return (
+    <>
+        {"Args:"}
+        <Indent>
+            <List doubleHardline>
+                {parameters.map(param => (
+                    <GoogleStyleDocParam
+                    name={param.name}
+                    type={param.type}
+                    optional={param.optional}
+                    >
+                    {param.doc}
+                    </GoogleStyleDocParam>
+                ))}
+            </List>
+        </Indent>
+    </>
+  );
+}
+
+export interface GoogleStyleDocReturnProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for parameters.
+ */
+export function GoogleStyleDocReturn(props: GoogleStyleDocReturnProps) {
+  return (
+    <>
+        {"Returns:"}
+        <Indent>
+            {props.message}
+        </Indent>
+    </>
+  );
+}
+
+export interface GoogleStyleDocRaisesProps {
+  message: string;
+}
+
+/**
+ * A component that creates a GoogleStyleDoc block for parameters.
+ */
+export function GoogleStyleDocRaises(props: GoogleStyleDocRaisesProps) {
+  return (
+    <>
+        {"Raises:"}
+        <Indent>
+            {props.message}
+        </Indent>
+    </>
+  );
+}
+
+export interface GoogleStyleFunctionDocProps {
+  description: Children[];
+  parameters: ParameterDescriptor[] | string[];
+  returns?: string;
+  raises: string[];
+}
+
+/**
+ * A component that creates a GoogleStyleFunctionDoc block for parameters.
+ */
+export function GoogleStyleFunctionDoc(props: GoogleStyleFunctionDocProps) {
+  return (
+    <>
+      <PyDoc>
+        <Show when={props.description !== undefined}>
+          <List doubleHardline>
+            {props.description.map(param => (
+                param
+            ))}
+          </List>
+        </Show>
+        <Show when={props.parameters.length > 0}>
+          <GoogleStyleDocParams parameters={props.parameters} />
+        </Show>
+        <Show when={props.returns !== undefined}>
+          <GoogleStyleDocReturn message={props.returns!} />
+        </Show>
+        <Show when={props.raises.length > 0}>
+          {props.raises.map(param => (
+            <GoogleStyleDocRaises message={param} />
+         ))}
+        </Show>
+      </PyDoc>
+      <hbr />
+    </>
+  );
+}
+
+export interface GoogleStyleClassDocProps {
+  description: Children[];
+  parameters: ParameterDescriptor[] | string[];
+}
+
+/**
+ * A component that creates a GoogleStyleClassDoc block for parameters.
+ */
+export function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
+  return (
+    <>
+      <PyDoc>
+        <Show when={props.description !== undefined}>
+          <List doubleHardline>
+            {props.description.map(param => (
+                param
+            ))}
+          </List>
+        </Show>
+        <Show when={props.parameters.length > 0}>
+          <GoogleStyleDocParams parameters={props.parameters} />
+        </Show>
+      </PyDoc>
+      <hbr />
+    </>
+  );
+}
+
+export interface PyDocExampleProps {
+  children: Children;
+}
+
+/**
+ * Create a PyDoc example, which is prepended by \>\>.
+ */
+export function PyDocExample(props: PyDocExampleProps) {
+  let children = childrenArray(() => props.children);
+  let lines: string[] = [];
+
+  if (children.length === 1 && typeof children[0] === "string") {
+    // Split, trim each line, and filter out empty lines
+    lines = children[0]
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+  } else {
+    // For non-string children, filter out empty/whitespace-only strings
+    lines = children
+      .map(child => (typeof child === "string" ? child : ""))
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+  }
+
+  return (
+    <>
+      <For each={lines}>
+        {(line) => (
+          <>
+            {">> "}{line}
+          </>
+        )}
+      </For>
+    </>
+  );
+}
+
+function normalizeParametersForDoc(
+  parameters: ParameterDescriptor[] | string[],
+): ParameterDescriptor[] {
+  if (parameters.some((p) => typeof p === "string")) {
+    return [];
+  }
+
+  return parameters as ParameterDescriptor[];
+}
+
+export interface PyDocProps {
+  children: Children;
+}
+
+/**
+ * A PyDoc comment. The children of this component are joined with two hard
+ * linebreaks. This is useful for creating PyDoc comments with multiple paragraphs.
+ */
+export function PyDoc(props: PyDocProps) {
+  return (
+    <>
+      {'"""'}
+      <align string="">
+        <hbr />
+        <List doubleHardline>
+            {childrenArray(() => props.children)}
+        </List>
+      </align>
+      <hbr />
+      {'"""'}
+    </>
+  );
+}
+
+export interface SimpleCommentBlockProps {
+  children: Children;
+}
+
+export function SimpleCommentBlock(props: SimpleCommentBlockProps) {
+  return (
+    <>
+      #{" "}
+      <align string="# ">
+        <Prose>{props.children}</Prose>
+      </align>
+    </>
+  );
+}
+
+export interface SimpleInlineCommentProps {
+  children: Children;
+}
+
+export function SimpleInlineComment(props: SimpleInlineCommentProps) {
+  return (
+    <>
+      {"  "}# <Prose>{props.children}</Prose>
+    </>
+  );
+}

--- a/packages/python/src/components/VariableDeclaration.tsx
+++ b/packages/python/src/components/VariableDeclaration.tsx
@@ -4,6 +4,7 @@ import {
   Name,
   OutputScope,
   OutputSymbolFlags,
+  Show,
   createSymbolSlot,
   effect,
   emitSymbol,
@@ -14,6 +15,7 @@ import {
 import { createPythonSymbol } from "../symbol-creation.js";
 import { BaseDeclarationProps } from "./Declaration.jsx";
 import { Value } from "./Value.jsx";
+import { SimpleCommentBlock } from "./index.js";
 
 export interface VariableDeclarationProps extends BaseDeclarationProps {
   /**
@@ -156,6 +158,10 @@ export function VariableDeclaration(props: VariableDeclarationProps) {
   const [renderRightSideOperator, rightSide] = getRightSide();
   return (
     <>
+      <Show when={Boolean(props.doc)}>
+        <SimpleCommentBlock children={props.doc} />
+        <hbr />
+      </Show>
       <CoreDeclaration symbol={sym}>
         {<Name />}
         {type}

--- a/packages/python/src/components/index.ts
+++ b/packages/python/src/components/index.ts
@@ -8,6 +8,7 @@ export * from "./FunctionCallExpression.js";
 export * from "./FunctionDeclaration.js";
 export * from "./ImportStatement.js";
 export * from "./MemberExpression.js";
+export * from "./PyDoc.js";
 export * from "./PythonBlock.js";
 export * from "./Reference.js";
 export * from "./SourceFile.js";

--- a/packages/python/test/pydocs.test.tsx
+++ b/packages/python/test/pydocs.test.tsx
@@ -1,0 +1,422 @@
+import { Prose, refkey } from "@alloy-js/core";
+import { d } from "@alloy-js/core/testing";
+import { describe, expect, it } from "vitest";
+import * as py from "../src/components/index.js";
+import { toSourceText } from "./utils.jsx";
+import { enumModule } from "../src/builtins/python.js";
+
+describe("PyDoc", () => {
+  it("formats properly", () => {
+    const res = toSourceText(
+      <py.PyDoc>
+        <Prose>
+          This is an example of a long docstring that will be broken in
+          lines. We will also render another paragraph after this one.
+        </Prose>
+        <Prose>
+          This is another paragraph, and there's a line break before it.
+        </Prose>
+      </py.PyDoc>,
+      { printOptions: { printWidth: 40 } },
+    );
+
+    expect(res).toRenderTo(
+      d`
+        """
+        This is an example of a long docstring
+        that will be broken in lines. We will
+        also render another paragraph after this
+        one.
+        
+        This is another paragraph, and there's a
+        line break before it.
+        """
+      `,
+    );
+  });
+});
+
+describe("PyDocExample", () => {
+  it("creates docstring with a code sample", () => {
+    const res = toSourceText(
+      <py.PyDoc>
+        <Prose>This is an example of a docstring with a code sample.</Prose>
+        <py.PyDocExample>print("Hello world!")</py.PyDocExample>
+      </py.PyDoc>,
+      { printOptions: { printWidth: 40 } },
+    );
+
+    expect(res).toRenderTo(
+      d`
+      """
+      This is an example of a docstring with a
+      code sample.
+      
+      >> print("Hello world!")
+      """
+      `,
+    );
+  });
+
+  it("creates docstring with more than one code sample", () => {
+    const res = toSourceText(
+      <py.PyDoc>
+        <Prose>This is an example of a docstring with a code sample.</Prose>
+        <py.PyDocExample>print("Hello world!")</py.PyDocExample>
+        <py.PyDocExample>print("Hello world again!")</py.PyDocExample>
+      </py.PyDoc>,
+      { printOptions: { printWidth: 40 } },
+    );
+
+    expect(res).toRenderTo(
+      d`
+      """
+      This is an example of a docstring with a
+      code sample.
+      
+      >> print("Hello world!")
+      
+      >> print("Hello world again!")
+      """
+      `,
+    );
+  });
+
+  it("creates docstring with a multiline code sample", () => {
+    const res = toSourceText(
+      <py.PyDoc>
+        <Prose>This is an example of a docstring with a code sample.</Prose>
+        <py.PyDocExample>
+          print("Hello world!")<br />
+          x = "Hello"<br />
+          print(x)
+        </py.PyDocExample>
+      </py.PyDoc>,
+      { printOptions: { printWidth: 40 } },
+    );
+
+    expect(res).toRenderTo(
+      d`
+      """
+      This is an example of a docstring with a
+      code sample.
+      
+      >> print("Hello world!")
+      >> x = "Hello"
+      >> print(x)
+      """
+      `,
+    );
+  });
+});
+
+describe("GoogleStyleDocParam", () => {
+  it("name only", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+        <py.GoogleStyleDocParam name="somebody" />
+      </py.PyDoc>
+  );
+  expect(res).toRenderTo(
+      d`
+          """
+          somebody
+          """
+          `,
+  );
+  });
+  it("name and type", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+        <py.GoogleStyleDocParam name="somebody" type="str" />
+      </py.PyDoc>
+  );
+  expect(res).toRenderTo(
+      d`
+          """
+          somebody (str)
+          """
+          `,
+  );
+  });
+  it("name, type and description", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+        <py.GoogleStyleDocParam name="somebody" type="str">Somebody's name.</py.GoogleStyleDocParam>
+      </py.PyDoc>
+  );
+  expect(res).toRenderTo(
+      d`
+          """
+          somebody (str): Somebody's name.
+          """
+          `,
+  );
+  });
+  it("name, type, description, and optional", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+        <py.GoogleStyleDocParam name="somebody" type="str" optional>Somebody's name.</py.GoogleStyleDocParam>
+      </py.PyDoc>
+  );
+  expect(res).toRenderTo(
+      d`
+          """
+          somebody (str, optional): Somebody's name.
+          """
+          `,
+  );
+  });
+  it("name, type, description, and optional with default value", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+        <py.GoogleStyleDocParam name="somebody" type="str" optional defaultValue="John Doe">
+          Somebody's name.
+        </py.GoogleStyleDocParam>
+      </py.PyDoc>
+  );
+  expect(res).toRenderTo(
+      d`
+        """
+        somebody (str, optional): Somebody's name. Defaults to \"John Doe\".
+        """
+        `,
+  );
+  });
+  it("name, type, description, and optional with default value with a very long description", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+      <py.GoogleStyleDocParam name="somebody" type="str" optional defaultValue="John Doe">
+          Somebody's name. This can be any string representing a person, whether
+          it's a first name, full name, nickname, or even a codename (e.g., "Agent
+          X"). It's used primarily for display purposes, logging, or greeting
+          messages and is not required to be unique or validated unless specified
+          by the caller.
+      </py.GoogleStyleDocParam>
+      <py.GoogleStyleDocParam name="somebody2" type="str">
+          Somebody's name. This can be any string representing a person, whether
+          it's a first name, full name, nickname, or even a codename (e.g., "Agent
+          X"). It's used primarily for display purposes, logging, or greeting
+          messages and is not required to be unique or validated unless specified
+          by the caller.
+      </py.GoogleStyleDocParam>
+      </py.PyDoc>,
+      { printOptions: { printWidth: 80 } },
+  );
+  expect(res).toRenderTo(
+      d`
+          """
+          somebody (str, optional): Somebody's name. This can be any string representing a
+              person, whether it's a first name, full name, nickname, or even a codename
+              (e.g., "Agent X"). It's used primarily for display purposes, logging, or
+              greeting messages and is not required to be unique or validated unless
+              specified by the caller. Defaults to \"John Doe\".
+          
+          somebody2 (str): Somebody's name. This can be any string representing a person,
+              whether it's a first name, full name, nickname, or even a codename (e.g.,
+              "Agent X"). It's used primarily for display purposes, logging, or greeting
+              messages and is not required to be unique or validated unless specified by
+              the caller.
+          """
+          `,
+  );
+  });
+  it("name, type, description, and optional with default value with a description containing a linebreak", () => {
+  const res = toSourceText(
+      <py.PyDoc>
+        <py.GoogleStyleDocParam name="somebody" type="str" optional defaultValue="John Doe">
+          Somebody's name. This is one line
+          <hbr />
+          This is another line.
+        </py.GoogleStyleDocParam>
+      </py.PyDoc>,
+      { printOptions: { printWidth: 80 } },
+  );
+  expect(res).toRenderTo(
+      d`
+          """
+          somebody (str, optional): Somebody's name. This is one line
+              This is another line. Defaults to \"John Doe\".
+          """
+          `,
+  );
+  });
+});
+
+describe("Full example", () => {
+  it("renders correctly in a Class", () => {
+      const doc = 
+        <py.GoogleStyleClassDoc
+            description={[
+                <Prose>This is an example of a long docstring that will be broken in lines. We will also render another paragraph after this one.</Prose>,
+                <py.PyDocExample>
+                print("Hello world!")<br />
+                x = "Hello"<br />
+                print(x)
+                </py.PyDocExample>
+            ]}
+            parameters={[
+                { name: "somebody", type: "str", optional: true, default: "John Doe", doc: "Somebody's name. This can be any string representing a person, whether it's a first name, full name, nickname, or even a codename (e.g., 'Agent X'). It's used primarily for display purposes, logging, or greeting messages and is not required to be unique or validated unless specified by the caller. Defaults to \"John Doe\"." },
+                { name: "somebody2", type: "str", doc: "Somebody's name. This can be any string representing a person, whether it's a first name, full name, nickname, or even a codename (e.g., 'Agent X'). It's used primarily for display purposes, logging, or greeting messages and is not required to be unique or validated unless specified by the caller." },
+            ]} />;
+      const res = toSourceText(
+        <py.ClassDeclaration name="A" doc={doc}>
+          <py.StatementList>
+            <py.VariableDeclaration name="just_name" />
+            <py.VariableDeclaration name="name_and_type" type="number" />
+            <py.VariableDeclaration
+              name="name_type_and_value"
+              type="number"
+              initializer={12}
+            />
+          </py.StatementList>
+        </py.ClassDeclaration>,
+        { printOptions: { printWidth: 80, tabWidth: 4 } });
+
+  expect(res).toRenderTo(
+      d`
+          class A:
+              """
+              This is an example of a long docstring that will be broken in lines. We will
+              also render another paragraph after this one.
+
+              >> print("Hello world!")
+              >> x = "Hello"
+              >> print(x)
+
+              Args:
+                  somebody (str, optional): Somebody's name. This can be any string
+                      representing a person, whether it's a first name, full name,
+                      nickname, or even a codename (e.g., 'Agent X'). It's used primarily
+                      for display purposes, logging, or greeting messages and is not
+                      required to be unique or validated unless specified by the caller.
+                      Defaults to \"John Doe\".
+
+                  somebody2 (str): Somebody's name. This can be any string representing a
+                      person, whether it's a first name, full name, nickname, or even a
+                      codename (e.g., 'Agent X'). It's used primarily for display
+                      purposes, logging, or greeting messages and is not required to be
+                      unique or validated unless specified by the caller.
+              """
+              just_name = None
+              name_and_type: number = None
+              name_type_and_value: number = 12
+
+
+          `,
+  );
+  });
+
+  it("renders correctly in a Function", () => {
+      const doc = 
+        <py.GoogleStyleFunctionDoc
+            description={[
+                <Prose>This is an example of a long docstring that will be broken in lines. We will also render another paragraph after this one.</Prose>,
+                <py.PyDocExample>
+                print("Hello world!")<br />
+                x = "Hello"<br />
+                print(x)
+                </py.PyDocExample>
+            ]}
+            parameters={[
+                { name: "somebody", type: "str", optional: true, default: "John Doe", doc: "Somebody's name. This can be any string representing a person, whether it's a first name, full name, nickname, or even a codename (e.g., 'Agent X'). It's used primarily for display purposes, logging, or greeting messages and is not required to be unique or validated unless specified by the caller. Defaults to \"John Doe\"." },
+                { name: "somebody2", type: "str", doc: "Somebody's name. This can be any string representing a person, whether it's a first name, full name, nickname, or even a codename (e.g., 'Agent X'). It's used primarily for display purposes, logging, or greeting messages and is not required to be unique or validated unless specified by the caller." },
+            ]}
+            returns="The return value. True for success, False otherwise."
+            raises={["ValueError: If somebody2 is equal to somebody."]} />;
+      const res = toSourceText(
+        <py.FunctionDeclaration name="some_function" doc={doc}>
+          <py.StatementList>
+            <py.VariableDeclaration name="just_name" />
+            <py.VariableDeclaration name="name_and_type" type="number" />
+            <py.VariableDeclaration
+              name="name_type_and_value"
+              type="number"
+              initializer={12}
+            />
+          </py.StatementList>
+        </py.FunctionDeclaration>,
+        { printOptions: { printWidth: 80, tabWidth: 4 } });
+
+  expect(res).toRenderTo(
+      d`
+          def some_function():
+              """
+              This is an example of a long docstring that will be broken in lines. We will
+              also render another paragraph after this one.
+
+              >> print("Hello world!")
+              >> x = "Hello"
+              >> print(x)
+
+              Args:
+                  somebody (str, optional): Somebody's name. This can be any string
+                      representing a person, whether it's a first name, full name,
+                      nickname, or even a codename (e.g., 'Agent X'). It's used primarily
+                      for display purposes, logging, or greeting messages and is not
+                      required to be unique or validated unless specified by the caller.
+                      Defaults to \"John Doe\".
+
+                  somebody2 (str): Somebody's name. This can be any string representing a
+                      person, whether it's a first name, full name, nickname, or even a
+                      codename (e.g., 'Agent X'). It's used primarily for display
+                      purposes, logging, or greeting messages and is not required to be
+                      unique or validated unless specified by the caller.
+
+              Returns:
+                  The return value. True for success, False otherwise.
+
+              Raises:
+                  ValueError: If somebody2 is equal to somebody.
+              """
+              just_name = None
+              name_and_type: number = None
+              name_type_and_value: number = 12
+
+
+          `,
+  );
+  });
+
+  it("renders correctly in a Variable", () => {
+    const res = toSourceText(
+      <py.VariableDeclaration name="myVar" initializer={42} doc="This is a very long docstring that will be broken in two lines when rendered. This part of the docstring will be in the second line." />,
+      { printOptions: { printWidth: 80, tabWidth: 4 } });
+
+    expect(res).toRenderTo(
+        d`
+            # This is a very long docstring that will be broken in two lines when rendered.
+            # This part of the docstring will be in the second line.
+            my_var = 42
+            `,
+    );
+  });
+
+  it("classic enum with explicit values", () => {
+    const result = toSourceText(
+      <py.EnumDeclaration
+        name="Color"
+        baseType="IntEnum"
+        members={[
+          { name: "RED", value: "1", doc: "The color red." },
+          { name: "GREEN", value: "2", doc: "The color green." },
+          { name: "BLUE", value: "3", doc: "The color blue." },
+        ]}
+        doc="An enum representing colors."
+      />,
+      { externals: [enumModule] },
+    );
+    const expected = d`
+      from enum import IntEnum
+
+      # An enum representing colors.
+      class Color(IntEnum):
+        RED = 1  # The color red.
+        GREEN = 2  # The color green.
+        BLUE = 3  # The color blue.
+
+
+    `;
+    expect(result).toRenderTo(expected);
+  });
+});


### PR DESCRIPTION
- GoogleStyleClassDoc: Google-style Class docstring
- GoogleStyleFunctionDoc: Google-style Function docstring
- SimpleCommentBlock: Simple comment block to be used in variables
- SimpleInlineComment: Simple comment meant to be used alongside Enum values