### PR TITLE
Create ClassDoc and FunctionDoc with style param

### DIFF
--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -136,12 +136,7 @@ export function GoogleStyleDocRaises(props: GoogleStyleDocRaisesProps) {
   );
 }
 
-export interface GoogleStyleFunctionDocProps {
-  description: Children[];
-  parameters: ParameterDescriptor[] | string[];
-  returns?: string;
-  raises: string[];
-}
+export interface GoogleStyleFunctionDocProps extends Omit<FunctionDocProps, "style"> {}
 
 /**
  * A component that creates a GoogleStyleFunctionDoc block for parameters.
@@ -170,10 +165,53 @@ export function GoogleStyleFunctionDoc(props: GoogleStyleFunctionDocProps) {
   );
 }
 
-export interface GoogleStyleClassDocProps {
+export interface FunctionDocProps {
   description: Children[];
   parameters: ParameterDescriptor[] | string[];
+  returns?: string;
+  raises: string[];
+  style?: "google";
 }
+
+/**
+ * A component that creates a FunctionDoc block for parameters.
+ */
+export function FunctionDoc(props: FunctionDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleFunctionDoc
+        description={props.description}
+        parameters={props.parameters}
+        returns={props.returns}
+        raises={props.raises}
+      />
+    );
+  }
+}
+
+export interface ClassDocProps {
+  description: Children[];
+  parameters: ParameterDescriptor[] | string[];
+  style?: "google";
+}
+
+/**
+ * A component that creates a ClassDoc block for parameters.
+ */
+export function ClassDoc(props: ClassDocProps) {
+  const style = props.style ?? "google";
+  if (style === "google") {
+    return (
+      <GoogleStyleClassDoc
+        description={props.description}
+        parameters={props.parameters}
+      />
+    );
+  }
+}
+
+export interface GoogleStyleClassDocProps extends Omit<ClassDocProps, "style"> {}
 
 /**
  * A component that creates a GoogleStyleClassDoc block for parameters.
@@ -193,6 +231,7 @@ export function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
     </>
   );
 }
+
 
 export interface PyDocExampleProps {
   children: Children;

--- a/packages/python/src/components/PyDoc.tsx
+++ b/packages/python/src/components/PyDoc.tsx
@@ -232,7 +232,6 @@ export function GoogleStyleClassDoc(props: GoogleStyleClassDocProps) {
   );
 }
 
-
 export interface PyDocExampleProps {
   children: Children;
 }

--- a/packages/python/test/pydocs.test.tsx
+++ b/packages/python/test/pydocs.test.tsx
@@ -279,7 +279,7 @@ describe("GoogleStyleDocParam", () => {
 describe("Full example", () => {
   it("renders correctly in a Class", () => {
     const doc = (
-      <py.GoogleStyleClassDoc
+      <py.ClassDoc
         description={[
           <Prose>
             This is an example of a long docstring that will be broken in lines.
@@ -307,6 +307,7 @@ describe("Full example", () => {
             doc: "Somebody's name. This can be any string representing a person, whether it's a first name, full name, nickname, or even a codename (e.g., 'Agent X'). It's used primarily for display purposes, logging, or greeting messages and is not required to be unique or validated unless specified by the caller.",
           },
         ]}
+        style="google"
       />
     );
     const res = toSourceText(
@@ -362,7 +363,7 @@ describe("Full example", () => {
 
   it("renders correctly in a Function", () => {
     const doc = (
-      <py.GoogleStyleFunctionDoc
+      <py.FunctionDoc
         description={[
           <Prose>
             This is an example of a long docstring that will be broken in lines.
@@ -392,6 +393,7 @@ describe("Full example", () => {
         ]}
         returns="The return value. True for success, False otherwise."
         raises={["ValueError: If somebody2 is equal to somebody."]}
+        style="google"
       />
     );
     const res = toSourceText(


### PR DESCRIPTION
Create ClassDoc and FunctionDoc with style param. The only valid value for now is "google", but it could be extended to support other styles in the future.